### PR TITLE
Add log_level INFO, besides DEBUG and NONE

### DIFF
--- a/mriapp/MriCaffe.py
+++ b/mriapp/MriCaffe.py
@@ -182,8 +182,12 @@ class MriCaffe(object):
         root_logger = logging.getLogger()
 
         # Send everything to console if debug mode
-        if self._get_config('mri-client', 'debug').lower() == 'true':
-            root_logger.level = logging.DEBUG
+        log_mode = self._get_config('mri-client', 'log_level').lower()
+        if log_mode == 'debug' or log_mode == 'info':
+            if log_mode == 'debug':
+                root_logger.level = logging.DEBUG
+            else:
+                root_logger.level = logging.INFO
             file_handler = logging.FileHandler(log_location)
             file_handler.setFormatter(log_formatter)
             root_logger.addHandler(file_handler)

--- a/mriapp/config.Template
+++ b/mriapp/config.Template
@@ -18,7 +18,7 @@ task_list = /home/user/path/to/task/list.txt	        ; Local list of tasks, simp
 ; ---=== Client Settings ===---
 [mri-client]
 log_location = ../mri.log                               ; Log save location
-debug = True                                            ; Enable for verbose logging and stdout
+log_level = DEBUG                                       ; "DEBUG", "INFO" or "NONE". Level of verbose logging and stdout (decreasing order)
 caffe_root = /home/user/caffe                           ; Root caffe directory. Caffe must be built!
 caffe_bin = ./build/tools/caffe                         ; Path to caffe binary from root caffe folder
 solver_type = Caffe                                     ; Currently only Caffe is possible


### PR DESCRIPTION
Instead of using two log modes determined by `debug=True` or `debug=False` in _config_ file, I added another mode `INFO` which output only the logs with log-level `INFO`. This is very useful for users who don't care the detail training process (therefore need to avoid outputting tons of detailed logs), but care about the final extremes of each hyper-parameter set.

This is will help further alleviate issue #5 
